### PR TITLE
Use output-rhythm mixin

### DIFF
--- a/_normalize.scss
+++ b/_normalize.scss
@@ -232,7 +232,7 @@ strong {
    */
 
   blockquote {
-    margin: rhythm(1) $indent-amount;
+    @include output-rhythm(margin, rhythm(1) $indent-amount);
   }
 }
 
@@ -328,7 +328,7 @@ h1 {
 
   p,
   pre {
-    margin: rhythm(1) 0;
+    @include output-rhythm(margin, rhythm(1) 0);
   }
 }
 
@@ -380,7 +380,7 @@ sub {
   menu,
   ol,
   ul {
-    margin: rhythm(1) 0;
+    @include output-rhythm(margin, rhythm(1) 0);
   }
 
   @if not $strict-normalize {
@@ -454,7 +454,7 @@ svg:not(:root) {
    */
 
   figure {
-    margin: rhythm(1) $indent-amount;
+    @include output-rhythm(margin, rhythm(1) $indent-amount);
   }
 }
 


### PR DESCRIPTION
If the $rhythm-unit is set to rem and $rem-with-px-fallback enabled expected behaviour is to output a px fallback wherever rems are used.

This works for the most part, but in one or two places where rhythm() is used it would output rems with no fallback, wrapping these lines in output-rhythm solves this.
