### PR TITLE
Fix invalid JSON in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Normalize-scss as a node packaged module",
   "style": "_normalize.scss",
   "files": [
-    "_normalize.scss",
+    "_normalize.scss"
   ],
   "homepage": "https://github.com/JohnAlbin/normalize-scss",
   "repository": {


### PR DESCRIPTION
Cannot install via npm because `package.json` contains invalid JSON