### PR TITLE
Fix _vertical-rhythm.scss issue #45

### DIFF
--- a/sass/normalize/_vertical-rhythm.scss
+++ b/sass/normalize/_vertical-rhythm.scss
@@ -33,10 +33,8 @@
 }
 
 @mixin normalize-rhythm($property, $values, $relative-to: $base-font-size) {
-  @if type-of($values) == 'list' {
-    $px-fallback: $values;
-  }
-  @else {
+  $px-fallback: $values;
+  @if type-of($values) != 'list' {
     $px-fallback: append((), $values);
   }
   $sep: list-separator($px-fallback);


### PR DESCRIPTION
This fixes the bespoke issue #45 where `$px-fallback` is undefined because of faulty variable scope.