### PR TITLE
Only assign Typey variables if not already assigned

### DIFF
--- a/fork-versions/default/_variables.scss
+++ b/fork-versions/default/_variables.scss
@@ -8,35 +8,35 @@
 $support-for: (
   ie:      9,
   '*':     -4,
-);
+) !default;
 
 // The font size set on the root html element.
-$base-font-size: 16px;
+$base-font-size: 16px !default;
 
 // The base line height determines the basic unit of vertical rhythm.
-$base-line-height: 24px;
+$base-line-height: 24px !default;
 
 // The length unit in which to output vertical rhythm values.
 // Supported values: px, em, rem.
-$base-unit: 'em';
+$base-unit: 'em' !default;
 
 // The default font family.
-$base-font-family: sans-serif;
+$base-font-family: sans-serif !default;
 
 // The font sizes for h1-h6.
-$h1-font-size: 2    * $base-font-size;
-$h2-font-size: 1.5  * $base-font-size;
-$h3-font-size: 1.17 * $base-font-size;
-$h4-font-size: 1    * $base-font-size;
-$h5-font-size: 0.83 * $base-font-size;
-$h6-font-size: 0.67 * $base-font-size;
+$h1-font-size: 2    * $base-font-size !default;
+$h2-font-size: 1.5  * $base-font-size !default;
+$h3-font-size: 1.17 * $base-font-size !default;
+$h4-font-size: 1    * $base-font-size !default;
+$h5-font-size: 0.83 * $base-font-size !default;
+$h6-font-size: 0.67 * $base-font-size !default;
 
 // The amount lists and blockquotes are indented.
-$indent-amount: 40px;
+$indent-amount: 40px !default;
 
 // The following variable controls whether normalize-scss will output
 // font-sizes, line-heights and block-level top/bottom margins that form a basic
 // vertical rhythm on the page, which differs from the original Normalize.css.
 // However, changing any of the variables above will cause
 // $normalize-vertical-rhythm to be automatically set to true.
-$normalize-vertical-rhythm: false;
+$normalize-vertical-rhythm: false !default;

--- a/fork-versions/typey/_variables.scss
+++ b/fork-versions/typey/_variables.scss
@@ -8,23 +8,23 @@
 $support-for: (
   ie:  9,  // IE 9-11
   '*': -4, // The last 4 versions of all other browsers.
-);
+) !default;
 
 // The font size set on the root html element.
-$base-font-size: 16px;
+$base-font-size: 16px !default;
 
 // The base line height determines the basic unit of vertical rhythm.
-$base-line-height: 24px;
+$base-line-height: 24px !default;
 
 // The length unit in which to output font size and margin values.
 // Supported values: px, em, rem.
-$base-unit: 'rem';
+$base-unit: 'rem' !default;
 
 // px fallbacks for rem units are needed for IE 8 and earlier.
-$rem-fallback: false;
+$rem-fallback: false !default;
 
 // The default font family.
-$base-font-family: sans-serif;
+$base-font-family: sans-serif !default;
 
 // The font sizes for h1-h6 expressed as tee shirt sizes.
 $font-size: (
@@ -34,10 +34,10 @@ $font-size: (
   m:   $base-font-size,
   s:   14px,
   xs:  10px,
-);
+) !default;
 
 // The amount lists and blockquotes are indented.
-$indent-amount: 40px;
+$indent-amount: 40px !default;
 
 // The following variable controls whether normalize-scss will output
 // font-sizes, line-heights and block-level top/bottom margins that form a basic


### PR DESCRIPTION
Attempting to use the typey fork directly from the normalize-scss npm module I noticed that my typey settings were overridden. This change uses the `!default` flag to only assign defaults in the typey and default fork versions. Note that the ruby-sass-compass fork version already uses `!default`.

In the case of typey I purposely omitted the `!default` flag on `$normalize-vertical-rhythm` since typey handles vertical rhythm and this variable is not used in this particular fork version.

Please let me know if you would like tests for overriding the defaults. If so I will add input-customized.scss and output-customized.css fixtures for typey. However, customization does not seem to be included in other tests.