### PR TITLE
Replace deprecated slash division by math.div() to prepare for Dart Sass 2.0.0

### DIFF
--- a/sass/normalize/_normalize-mixin.scss
+++ b/sass/normalize/_normalize-mixin.scss
@@ -1,4 +1,6 @@
 // Helper function for the normalize() mixin.
+@use "sass:math";
+
 @function _normalize-include($section, $exclude: null) {
   // Initialize the global variables needed by this function.
   @if not global_variable_exists(_normalize-include) {
@@ -61,10 +63,10 @@
       @if $base-font-size != 16px or $normalize-vertical-rhythm {
         // Correct old browser bug that prevented accessible resizing of text
         // when root font-size is set with px or em.
-        font-size: ($base-font-size / 16px) * 100%;
+        font-size: math.div($base-font-size, 16px) * 100%;
       }
       @if $normalize-vertical-rhythm {
-        line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */
+        line-height: math.div($base-line-height, $base-font-size) * 1em; /* 1 */
       }
       @else {
         line-height: 1.15; /* 1 */
@@ -419,7 +421,7 @@
       font-family: if($base-font-family, $base-font-family, sans-serif); /* 1 */
       font-size: 100%; /* 1 */
       @if $normalize-vertical-rhythm {
-        line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */
+        line-height: math.div($base-line-height, $base-font-size) * 1em; /* 1 */
       }
       @else {
         line-height: 1.15; /* 1 */

--- a/sass/normalize/_vertical-rhythm.scss
+++ b/sass/normalize/_vertical-rhythm.scss
@@ -5,15 +5,17 @@
 // CSS. If you are looking for a robust solution, look at the excellent Typey
 // library. @see https://github.com/jptaranto/typey
 
+@use "sass:math";
+
 @function normalize-rhythm($value, $relative-to: $base-font-size, $unit: $base-unit) {
   @if unit($value) != px {
     @error "The normalize vertical-rhythm module only supports px inputs. The typey library is better.";
   }
   @if $unit == rem {
-    @return ($value / $base-font-size) * 1rem;
+    @return math.div($value, $base-font-size) * 1rem;
   }
   @else if $unit == em {
-    @return ($value / $relative-to) * 1em;
+    @return math.div($value, $relative-to) * 1em;
   }
   @else { // $unit == px
     @return $value;
@@ -52,7 +54,7 @@
 }
 
 @mixin normalize-line-height($font-size, $min-line-padding: 2px) {
-  $lines: ceil($font-size / $base-line-height);
+  $lines: ceil(math.div($font-size, $base-line-height));
   // If lines are cramped include some extra leading.
   @if ($lines * $base-line-height - $font-size) < ($min-line-padding * 2) {
     $lines: $lines + 1;


### PR DESCRIPTION
Since Dart Sass 1.33.0 deprecation warnings regarding using slash for divisions are printed to the console when using normalize-scss in the same project. In order to prepare for the Dart Sass 2.0.0 release and to make sure that normalize-scss can be used in the future, the affected code parts have to be updated.

A blog post on the topic can be found here: https://sass-lang.com/documentation/breaking-changes/slash-div.

The issue has already been reported in the main repository here: https://github.com/JohnAlbin/normalize-scss/issues/148. 

This PR now aims to resolve that issue.